### PR TITLE
chore:add validate for number of clusters in config file

### DIFF
--- a/exporter/type.go
+++ b/exporter/type.go
@@ -44,6 +44,9 @@ type (
 )
 
 func (s *StaticConfig) Validate() error {
+	if len(s.Clusters) == 0 {
+		return fmt.Errorf("at least one cluster in config")
+	}
 	for _, cluster := range s.Clusters {
 		for _, instance := range cluster.Instances {
 			switch instance.ComponentType {

--- a/exporter/type.go
+++ b/exporter/type.go
@@ -45,7 +45,7 @@ type (
 
 func (s *StaticConfig) Validate() error {
 	if len(s.Clusters) == 0 {
-		return fmt.Errorf("at least one cluster in config")
+		return fmt.Errorf("at least one cluster should be configured")
 	}
 	for _, cluster := range s.Clusters {
 		for _, instance := range cluster.Instances {


### PR DESCRIPTION
When I pasted the wrong config in config.yaml, the function `CollectFromStaticConfig` in the exporter kept running but did nothing because of the zero length of clusters.
In my opinion, the exporter should exit when there don't have any cluster in config.yaml.